### PR TITLE
Emit data without formatting

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -20,13 +20,12 @@ function fluentAppender(tag, options){
     logSender.end();
   });
   var appender = function(loggingEvent){
-    var data =  util.format.apply(null, loggingEvent.data);
     var rec = {
       timestamp: loggingEvent.startTime.getTime(),
       category: loggingEvent.categoryName,
       levelInt: loggingEvent.level.level,
       levelStr: loggingEvent.level.levelStr,
-      data: data
+      data: loggingEvent.data
     };
     logSender.emit(loggingEvent.level.levelStr, rec);
   };

--- a/test/test.log4js.js
+++ b/test/test.log4js.js
@@ -29,7 +29,7 @@ describe("log4js", function(){
           finish(function(data){
             expect(data[0].tag).to.be.equal('debug.INFO');
             expect(data[0].data).exist;
-            expect(data[0].data.data).to.be.equal('foo bar');
+            expect(data[0].data.data).to.deep.equal(['foo %s', 'bar']);
             expect(data[0].data.category).to.be.equal('mycategory');
             expect(data[0].data.timestamp).exist;
             expect(data[0].data.levelInt).exist;


### PR DESCRIPTION
I think formatting data with util.format is extra feature in the log4js appender.
Emitting data should be treated AS IS.

Run below codes,

```js
logger.info({
    name: 'fluentd',
    gender: 'male'
}, 'new user', 1242)
```

then emitted data are,

- with formatting
    - "{ name: 'fluentd', gender: 'male' } 'new user' 1242"
- without formatting
    - [ { name: 'fluentd', gender: 'male' }, 'new user', 1242 ]

To retrieve JavaScript object from data with formatting needs extra and troublesome codes.

This request may have a impact on existing users, so applying this changes may be difficult.

影響考えるとめんどくさいとおもいますがよろしくおねがいします
