### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
+  - 0.10
+  - 0.12


### PR DESCRIPTION
Node.js v0.6 and v0.8 are EOL.
Node.js v.0.10 and v0.12 are available for now.