### PR TITLE
Use `Date.now()` instead of `(new Date()).getTime()`

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -80,8 +80,7 @@ FluentSender.prototype._makePacketItem = function(label, data, time){
   var tag = label ? [self.tag, label].join('.') : self.tag;
 
   if (typeof time != "number") {
-    var dateTime = time || new Date();
-    time = dateTime.getTime() / this._timeResolution;
+    time = (time ? time.getTime() : Date.now()) / this._timeResolution;
   }
 
   var packet = [tag, time, data];


### PR DESCRIPTION
Because `Date.now()` is faster than `(new Date()).getTime()`.