### PR TITLE
.travis.yml: 4.x, 0.10 not shown as 0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.12
-  - iojs-v1
-  - iojs-v2
-  - iojs-v3
-  - 4.0
+  - "0.10"
+  - "0.12"
+  - "iojs-v1"
+  - "iojs-v2"
+  - "iojs-v3"
+  - "4"


### PR DESCRIPTION
Travis shows 0.10 as 0.1 if not specified as string.
For consistency, changing all others to strings as well.

Also, specifying "4", not "4.0" as node 4 specifier. It takes latest 4.x.y (there is already 4.1.0 out there).