### PR TITLE
add options "levelTag" to control appending LOG_LEVEL to Tag in log4j…

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -29,7 +29,11 @@ function fluentAppender(tag, options){
       levelStr: loggingEvent.level.levelStr,
       data: data
     };
-    logSender.emit(loggingEvent.level.levelStr, rec);
+    if (options.levelTag != false) {
+      logSender.emit(loggingEvent.level.levelStr, rec);
+    } else {
+      logSender.emit(rec);
+    }
   };
   return appender;
 }


### PR DESCRIPTION
Hi.
I add "levelTag" option to control appending LOG_LEVEL label to the Tag or not in log4jsAppender.
I want to use it like bellow.

```
        var appender = log4jsSupport.appender('mytag', {port: server.port, levelTag: false});
        log4js.addAppender(appender);
        var logger = log4js.getLogger('mycategory');
        logger.info('foo %s', 'bar');
```

The output tag becomes 'mytag' but 'mytag.INFO'.
Thanks.