### PR TITLE
[WIP] Use latest msgpack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "iojs-v1"
   - "iojs-v2"
+  - "iojs-v3"
+  - "4.0"
+  - "4.1"
+  - "4.2"

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -1,7 +1,7 @@
 'use strict';
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
-var pack = require('msgpack5')().encode;
+var pack = require('msgpack').pack;
 var net = require('net');
 
 

--- a/lib/testHelper.js
+++ b/lib/testHelper.js
@@ -1,7 +1,7 @@
 'use strict';
 var net = require('net');
 var fs = require('fs');
-var msgpack = require('msgpack5')();
+var msgpack = require('msgpack');
 
 function MockFluentdServer(){
   var self = this;
@@ -14,10 +14,8 @@ function MockFluentdServer(){
     socket.on('end', function(){
       delete(self._clients[clientKey]);
     });
-
-    var decoder = msgpack.decoder();
-    socket.pipe(decoder);
-    decoder.on('data', function(m) {
+    var ms = new msgpack.Stream(socket);
+    ms.on('msg', function(m){
       self._received.push({
         tag: m[0],
         time: m[1],

--- a/package.json
+++ b/package.json
@@ -22,11 +22,10 @@
     "url": "http://github.com/fluent/fluent-logger-node"
   },
   "engines": {
-    "node": ">=0.10.30 < 4"
+    "node": ">=0.12.0"
   },
   "dependencies": {
-    "msgpack": "0.2.7",
-    "msgpack5": "^3.1.0"
+    "msgpack": "~1.0"
   },
   "devDependencies": {
     "mocha": "",

--- a/test/test.sender.js
+++ b/test/test.sender.js
@@ -115,13 +115,7 @@ describe("FluentSender", function(){
     runServer(function(server, finish){
       var s = new sender.FluentSender('debug', {port: server.port});
       s.emit('foo', 'bar', function(){
-
-        // capture ECONNRESET when closing server
-        s.on('error', function(err){
-          if (err.code === 'ECONNRESET') return;
-          throw err;
-        });
-
+        // connected
         server.close(function(){
           // waiting for the server closing all client socket.
           (function waitForUnwritable(){


### PR DESCRIPTION
This PR do followings:

* Drop node v0.10 support
* Use latest msgpack (1.0.2) for node v0.12 or later
* Use latest msgpack instead of mgspack5 for performance

See #38 .