### PR TITLE
fixed timestamp format according to fluent in_forward module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Simple configuration is following:
 Singleton style
 
     var logger = require('fluent-logger')
-    // The 2nd argument can be omitted. Here is a defualt value for options.
+    // The 2nd argument can be omitted. Here is a default value for options.
     logger.configure('tag', {
        host: 'localhost',
        port: 24224,
@@ -143,10 +143,6 @@ See [socket.setTimeout][2]
 
 Set the reconnect interval in milliseconds.
 If error occurs then reconnect after this interval.
-
-**verbose**
-
-If set `true`, verbose output.
 
 [1]: https://nodejs.org/api/net.html#net_socket_connect_path_connectlistener
 [2]: https://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -13,7 +13,6 @@ function FluentSender(tag, options){
   this.path = options.path;
   this.timeout = options.timeout || 3.0;
   this.reconnectInterval = options.reconnectInterval || 600000; // Default is 10 minutes
-  this.verbose = this.verbose || false;
   this._timeResolution = options.milliseconds ? 1 : 1000;
   this._socket = null;
   this._sendQueue  = [];    // queue for items waiting for being sent.

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -83,7 +83,7 @@ FluentSender.prototype._makePacketItem = function(label, data, time){
   var tag = label ? [self.tag, label].join('.') : self.tag;
 
   if (typeof time != "number") {
-    time = (time ? time.getTime() : Date.now()) / this._timeResolution;
+    time = Math.floor((time ? time.getTime() : Date.now()) / this._timeResolution);
   }
 
   var packet = [tag, time, data];

--- a/test/test.sender.js
+++ b/test/test.sender.js
@@ -64,11 +64,12 @@ describe("FluentSender", function(){
   it('should allow to emit with a custom timestamp', function(done){
     runServer(function(server, finish){
       var s = new sender.FluentSender('debug', {port: server.port});
-      var timestamp = new Date();
+      var timestamp = new Date(2222, 12, 04);
+      var timestamp_seconds_since_epoch = Math.floor(timestamp.getTime() / 1000);
 
       s.emit("1st record", "1st data", timestamp, function() {
         finish(function(data) {
-          expect(data[0].time).to.be.equal(timestamp.getTime() / 1000);
+          expect(data[0].time).to.be.equal(timestamp_seconds_since_epoch);
           done();
         });
       });
@@ -78,7 +79,7 @@ describe("FluentSender", function(){
   it('should allow to emit with a custom numeric timestamp', function(done){
     runServer(function(server, finish){
       var s = new sender.FluentSender('debug', {port: server.port});
-      var timestamp = new Date().getTime() / 1000;
+      var timestamp = Math.floor(new Date().getTime() / 1000);
 
       s.emit("1st record", "1st data", timestamp, function() {
         finish(function(data) {
@@ -235,7 +236,7 @@ describe("FluentSender", function(){
       expect: {
         tag: 'debug',
         data: { bar: 1 },
-        time: 1384434467.952
+        time: 1384434467
       }
     }
   ].forEach(function(testCase) {


### PR DESCRIPTION
According to http://docs.fluentd.org/articles/in_forward, the timestamp should be an integer 

> The time value is a platform specific integer and is based on the output of Ruby’s Time.now.to_i function. On Linux, BSD and MAC systems, this is the number of seconds since 1970.

instead, fluent-logger-node would put either milliseconds since epoch or a seconds since epoch, but as a float. Both are wrong. This was causing problems when used fluentd with https://github.com/fangli/fluent-plugin-influxdb

Also cleaned up README a bit.