### PR TITLE
Optional tag prefix

### DIFF
--- a/lib/errors/missing-tag.js
+++ b/lib/errors/missing-tag.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function MissingTag(message, extra) {
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = message;
+  this.extra = extra;
+};
+
+require('util').inherits(module.exports, Error);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,17 +6,11 @@ var log4jsSupport = require('../lib/log4js');
 
 module.exports = {
   configure: function(config){
-    if (typeof(config) === 'string') {
       sender.end();
       var tag = config;
       var options = arguments[1];
       sender = new FluentSender(tag, options);
       sender._setupErrorHandler();
-    } else {
-      // For log4js
-      sender.end();
-      return log4jsSupport.appender(config);
-    }
   },
 
   createFluentSender: function(tag, options){

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -3,6 +3,7 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var msgpack = require('msgpack-lite');
 var net = require('net');
+var MissingTagError = require('./errors/missing-tag');
 
 
 function FluentSender(tag, options){
@@ -40,6 +41,10 @@ FluentSender.prototype.emit = function(/*[label] <data>, [timestamp], [callback]
   var item = self._makePacketItem(label, data, timestamp);
 
   item.callback = callback;
+
+  if (typeof label === 'undefined' || label === null) {
+    return callback && callback(new MissingTagError());
+  }
 
   self._sendQueue.push(item);
   self._sendQueueTail++;
@@ -79,7 +84,7 @@ FluentSender.prototype._close = function(){
 
 FluentSender.prototype._makePacketItem = function(label, data, time){
   var self = this;
-  var tag = label ? [self.tag, label].join('.') : self.tag;
+  var tag = label ? (self.tag ? [self.tag, label].join('.') : label) : self.tag;
 
   if (typeof time != "number") {
     time = Math.floor((time ? time.getTime() : Date.now()) / this._timeResolution);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -42,7 +42,7 @@ FluentSender.prototype.emit = function(/*[label] <data>, [timestamp], [callback]
 
   item.callback = callback;
 
-  if (typeof label === 'undefined' || label === null) {
+  if (typeof item.tag === 'undefined' || item.tag === null) {
     return callback && callback(new MissingTagError());
   }
 

--- a/test/test.sender.js
+++ b/test/test.sender.js
@@ -265,6 +265,118 @@ describe("FluentSender", function(){
     });
   });
 
+  [
+    {
+      name: 'tag and record',
+      args: ['foo', { bar: 1 }],
+      expect: {
+        tag: 'foo',
+        data: { bar: 1 }
+      }
+    },
+
+    {
+      name: 'tag, record and time',
+      args: ['foo', { bar: 1 }, 12345],
+      expect: {
+        tag: 'foo',
+        data: { bar: 1 },
+        time: 12345
+      }
+    },
+
+    {
+      name: 'tag, record and callback',
+      args: ['foo', { bar: 1 }, function cb() { cb.called = true; }],
+      expect: {
+        tag: 'foo',
+        data: { bar: 1 },
+      }
+    },
+
+    {
+      name: 'tag, record, time and callback',
+      args: ['foo', { bar: 1 }, 12345, function cb() { cb.called = true; }],
+      expect: {
+        tag: 'foo',
+        data: { bar: 1 },
+        time: 12345
+      }
+    },
+
+    {
+      name: 'record',
+      args: [{ bar: 1 }],
+      expect: {
+        tag: null,
+        data: { bar: 1 }
+      }
+    },
+
+    {
+      name: 'record and time',
+      args: [{ bar: 1 }, 12345],
+      expect: {
+        tag: null,
+        data: { bar: 1 },
+        time: 12345
+      }
+    },
+
+    {
+      name: 'record and callback',
+      args: [{ bar: 1 }, function cb(){ cb.called = true; }],
+      expect: {
+        tag: null,
+        data: { bar: 1 }
+      }
+    },
+
+    {
+      name: 'record, time and callback',
+      args: [{ bar: 1 }, 12345, function cb(){ cb.called = true; }],
+      expect: {
+        tag: null,
+        data: { bar: 1 },
+        time: 12345
+      }
+    },
+
+    {
+      name: 'record and date object',
+      args: [{ bar: 1 }, new Date(1384434467952)],
+      expect: {
+        tag: null,
+        data: { bar: 1 },
+        time: 1384434467
+      }
+    }
+  ].forEach(function(testCase) {
+    it('should send records with '+testCase.name+' arguments without a default tag', function(done){
+      runServer(function(server, finish){
+        var s1 = new sender.FluentSender(null, { port: server.port });
+        s1.emit.apply(s1, testCase.args);
+
+        finish(function(data){
+          expect(data[0].tag).to.be.equal(testCase.expect.tag);
+          expect(data[0].data).to.be.deep.equal(testCase.expect.data);
+          if (testCase.expect.time) {
+            expect(data[0].time).to.be.deep.equal(testCase.expect.time);
+          }
+
+          testCase.args.forEach(function(arg) {
+            if (typeof arg === "function") {
+              expect(arg.called, "callback must be called").to.be.true;
+            }
+          });
+
+          done();
+        });
+
+      });
+    });
+  });
+
   it('should set max listeners', function(done){
     var s = new sender.FluentSender('debug');
     if (EventEmitter.prototype.getMaxListeners) {

--- a/test/test.sender.js
+++ b/test/test.sender.js
@@ -302,54 +302,6 @@ describe("FluentSender", function(){
         data: { bar: 1 },
         time: 12345
       }
-    },
-
-    {
-      name: 'record',
-      args: [{ bar: 1 }],
-      expect: {
-        tag: null,
-        data: { bar: 1 }
-      }
-    },
-
-    {
-      name: 'record and time',
-      args: [{ bar: 1 }, 12345],
-      expect: {
-        tag: null,
-        data: { bar: 1 },
-        time: 12345
-      }
-    },
-
-    {
-      name: 'record and callback',
-      args: [{ bar: 1 }, function cb(){ cb.called = true; }],
-      expect: {
-        tag: null,
-        data: { bar: 1 }
-      }
-    },
-
-    {
-      name: 'record, time and callback',
-      args: [{ bar: 1 }, 12345, function cb(){ cb.called = true; }],
-      expect: {
-        tag: null,
-        data: { bar: 1 },
-        time: 12345
-      }
-    },
-
-    {
-      name: 'record and date object',
-      args: [{ bar: 1 }, new Date(1384434467952)],
-      expect: {
-        tag: null,
-        data: { bar: 1 },
-        time: 1384434467
-      }
     }
   ].forEach(function(testCase) {
     it('should send records with '+testCase.name+' arguments without a default tag', function(done){
@@ -364,6 +316,52 @@ describe("FluentSender", function(){
             expect(data[0].time).to.be.deep.equal(testCase.expect.time);
           }
 
+          testCase.args.forEach(function(arg) {
+            if (typeof arg === "function") {
+              expect(arg.called, "callback must be called").to.be.true;
+            }
+          });
+
+          done();
+        });
+
+      });
+    });
+  });
+
+  [
+    {
+      name: 'record',
+      args: [{ bar: 1 }]
+    },
+
+    {
+      name: 'record and time',
+      args: [{ bar: 1 }, 12345]
+    },
+
+    {
+      name: 'record and callback',
+      args: [{ bar: 1 }, function cb(){ cb.called = true; }]
+    },
+
+    {
+      name: 'record, time and callback',
+      args: [{ bar: 1 }, 12345, function cb(){ cb.called = true; }]
+    },
+
+    {
+      name: 'record and date object',
+      args: [{ bar: 1 }, new Date(1384434467952)]
+    }
+  ].forEach(function(testCase) {
+    it('should not send records with '+testCase.name+' arguments without a default tag', function(done){
+      runServer(function(server, finish){
+        var s1 = new sender.FluentSender(null, { port: server.port });
+        s1.emit.apply(s1, testCase.args);
+
+        finish(function(data){
+          expect(data.length).to.be.equal(0);
           testCase.args.forEach(function(arg) {
             if (typeof arg === "function") {
               expect(arg.called, "callback must be called").to.be.true;


### PR DESCRIPTION
- Add error when tag is missing
- Add testing

I removed the log4js setup under configure as I don't feel like it belongs there. Configure should only be used to setup the default/main sender. If someone were to want log4js support they should explicitly call the support functions to initialize the appender.