### PR TITLE
Additional Context Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ Change the protocol to at-least-once. The logger waits the ack from destination.
 
 This option is used when requireAckResponse is true. The default is 190. This default value is based on popular `tcp_syn_retries`.
 
+**tags**
+
+Inject additional data into every message. This is useful for environment tags or application functions. For example:
+
+```
+tags: {
+  env: 'DEV',
+  function: 'API'
+}
+```
+
 ## License
 
 Apache License, Version 2.0.

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -42,7 +42,6 @@ FluentSender.prototype.emit = function(/*[label] <data>, [timestamp], [callback]
   // Last argument is an optional callback
   if (typeof args[0] === "function") callback = args.shift();
 
-
   if (typeof data === "object") {
     var additionalData = util._extend({}, this.tags);
     data = util._extend(additionalData, data);

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -11,6 +11,7 @@ var FluentLoggerError = require('./logger-error');
 function FluentSender(tag_prefix, options){
   options = options || {};
   this.tag_prefix = tag_prefix;
+  this.tags = options.tags || {};
   this.host = options.host || 'localhost';
   this.port = options.port || 24224;
   this.path = options.path;
@@ -41,6 +42,11 @@ FluentSender.prototype.emit = function(/*[label] <data>, [timestamp], [callback]
   // Last argument is an optional callback
   if (typeof args[0] === "function") callback = args.shift();
 
+
+  if (typeof data === "object") {
+    var additionalData = util._extend({}, this.tags);
+    data = util._extend(additionalData, data);
+  }
 
   var self = this;
   var item = self._makePacketItem(label, data, timestamp);

--- a/test/test.sender.js
+++ b/test/test.sender.js
@@ -91,6 +91,19 @@ describe("FluentSender", function(){
     });
   });
 
+  it('should allow to emit with a custom tag', function(done){
+    runServer({}, function(server, finish){
+      var s = new sender.FluentSender('debug', {port: server.port, tags: {custom: 'tag'}});
+
+      s.emit("1st record", { message: "1st data" }, function() {
+        finish(function(data) {
+          expect(data[0].data.custom).to.be.equal('tag');
+          done();
+        });
+      });
+    });
+  });
+
   it('should resume the connection automatically and flush the queue', function(done){
     var s = new sender.FluentSender('debug');
     s.emit('1st record', { message: '1st data' });


### PR DESCRIPTION
I use a FluentD logger in Java which allows for additional data to be sent with every message. This is very useful when I'm sending data from both dev and prod environemnts and multiple apps all into the same EFK stack. This PR lets me inject those environment variables in at runtime so I can filter down the logs in Kibana.