### PR TITLE
Be not so verbose with console.log /error

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ Change the protocol to at-least-once. The logger waits the ack from destination.
 
 This option is used when requireAckResponse is true. The default is 190. This default value is based on popular `tcp_syn_retries`.
 
+**internalLogger**
+
+Set internal logger object for FluentLogger. Use `console` by default.
+This logger requires `info` and `error` method.
+
 ## License
 
 Apache License, Version 2.0.

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -22,6 +22,7 @@ function FluentSender(tag_prefix, options){
   this.reconnectInterval = options.reconnectInterval || 600000; // Default is 10 minutes
   this.requireAckResponse = options.requireAckResponse;
   this.ackResponseTimeout = options.ackResponseTimeout || 190000; // Default is 190 seconds
+  this.internalLogger = options.internalLogger || console;
   this._timeResolution = options.milliseconds ? 1 : 1000;
   this._socket = null;
   this._data = null;
@@ -238,12 +239,12 @@ FluentSender.prototype._setupErrorHandler = function _setupErrorHandler() {
     return;
   }
   self.on('error', function(error) {
-    console.error('Fluentd error', error);
-    console.info('Fluentd will reconnect after ' + self.reconnectInterval / 1000 + ' seconds');
+    self.internalLogger.error('Fluentd error', error);
+    self.internalLogger.info('Fluentd will reconnect after ' + self.reconnectInterval / 1000 + ' seconds');
     setTimeout(function() {
-      console.info("Fluentd is reconnecting...");
+      self.internalLogger.info("Fluentd is reconnecting...");
       self._connect(function() {
-        console.info('Fluentd reconnection finished!!');
+        self.internalLogger.info('Fluentd reconnection finished!!');
       });
     }, self.reconnectInterval);
   });


### PR DESCRIPTION
When socket connection fails and reconnection is tried.. It's using console.log / error.  Please add option to make it silent