### PR TITLE
Mark log4js 2.0 and later as unsupported

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "mocha": "",
     "chai": "",
-    "log4js": "",
+    "log4js": "<2",
     "async": "",
     "winston": ""
   },


### PR DESCRIPTION
This is a workaround for #70 to pass tests on Travis CI.