### PR TITLE
bugfix/winston transport - callback function should be invoked asynchronously

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -41,12 +41,13 @@ fluentTransport.prototype.log = function(level, message, meta, callback) {
   sender.emit(data, (error) => {
     if (error) {
       this.emit('error', error);
+      callback(error, false);
     } else {
       this.emit('logged');
+      callback(null, true);
     }
   });
 
-  callback(null, true);
 };
 
 fluentTransport.prototype.name = 'fluent';


### PR DESCRIPTION
Current implementation always successfully resolves the operation even if fluentd responds with an Error.