### PR TITLE
Support configure loglevel

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -23,7 +23,7 @@ function fluentTransport(tag, options) {
 
   this.sender = new sender.FluentSender(tag, options);
 
-  Transport.call(this);
+  Transport.call(this, options);
 }
 
 util.inherits(fluentTransport, Transport);


### PR DESCRIPTION
現状の挙動では、ログレベルが`debug`以下のログはfluentdに送られない仕様のようです。
`level`パラメタを指定した`options`を`Transport`に渡すことで、ログレベル設定により
送られるログのレベルを変更できるようにしてみました。
* [winston#console.js](https://github.com/winstonjs/winston/blob/master/lib/winston/transports/console.js#L22)を参考にしました
* `loglevel`で指定したレベル以上のログがfluentdに送られることを確認しています

  ```
    var logger = require('fluent-logger').createFluentSender('tag_prefix', {
        host: 'localhost',
        port: 24224,
        level: "debug", // <-- add
        timeout: 3.0,
        reconnectInterval: 600000 // 10 minutes
    });
  ```