### PR TITLE
sender: Use `waitToWrite()` to avoid writing to closed socket.

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -295,33 +295,38 @@ FluentSender.prototype._flushSendQueue = function() {
     return;
 
   this._flushingSendQueue = true;
-  let waitToWrite = () => {
-    if (!this._socket) {
-      this._flushingSendQueue = false;
-      return;
-    }
+  process.nextTick(() => {
+    this._waitToWrite();
+  });
+};
 
-    if (this._socket.writable) {
-      if (this._eventMode === 'Message') {
+FluentSender.prototype._waitToWrite = function() {
+  if (!this._socket) {
+    this._flushingSendQueue = false;
+    return;
+  }
+
+  if (this._socket.writable) {
+    if (this._eventMode === 'Message') {
+      this._doFlushSendQueue();
+    } else {
+      if (this._sendQueueSize >= this._sendQueueSizeLimit) {
+        this._flushSendQueueTimeoutId && clearTimeout(this._flushSendQueueTimeoutId);
         this._doFlushSendQueue();
       } else {
-        if (this._sendQueueSize >= this._sendQueueSizeLimit) {
-          this._flushSendQueueTimeoutId && clearTimeout(this._flushSendQueueTimeoutId);
+        this._flushSendQueueTimeoutId && clearTimeout(this._flushSendQueueTimeoutId);
+        this._flushSendQueueTimeoutId = setTimeout(() => {
           this._doFlushSendQueue();
-        } else {
-          this._flushSendQueueTimeoutId && clearTimeout(this._flushSendQueueTimeoutId);
-          this._flushSendQueueTimeoutId = setTimeout(() => {
-            this._doFlushSendQueue();
-          }, this._flushInterval);
-        }
+        }, this._flushInterval);
       }
-
-    } else {
-      process.nextTick(waitToWrite);
     }
-  };
-  process.nextTick(waitToWrite);
-};
+
+  } else {
+    process.nextTick(() => {
+      this._waitToWrite();
+    });
+  }
+}
 
 FluentSender.prototype._doFlushSendQueue = function(timeoutId) {
   if (this._eventMode === 'Message') {
@@ -375,7 +380,7 @@ FluentSender.prototype._doWrite = function(packet, options, timeoutId, callbacks
           callback && callback();
         });
         process.nextTick(() => {
-          this._doFlushSendQueue(); // if socket is still available
+          this._waitToWrite();
         });
       });
       timeoutId = setTimeout(() => {
@@ -389,7 +394,7 @@ FluentSender.prototype._doWrite = function(packet, options, timeoutId, callbacks
         callback && callback();
       });
       process.nextTick(() => {
-        this._doFlushSendQueue(); // if socket is still available
+        this._waitToWrite();
       });
     }
   });


### PR DESCRIPTION
### What is this patch?

The current '_doWrite' will push the `_doFlushSendQueue` callback
to the event loop queue after a successful write.

The problem is that the socket might be closed by the time the
enqueued `_doFlushSendQueue` callback gets called, and in this case,
it would just crash hard with the following error:

    TypeError: Cannot read property 'write' of null

We can avoid this issue by enforcing the logger to call the `waitToWrite`
routine before `_doFlushSendQueue`.

### Note

This patch fixes the issue reported by #83.