### PR TITLE
Support TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,14 @@ Set username for user based authentication. Default values is empty string.
 
 Set password for user based authentication. Default values is empty string.
 
+**tls**
+
+Enable TLS for socket.
+
+**tlsOptions**
+
+Options to pass to tls.connect when tls is true.
+
 **internalLogger**
 
 Set internal logger object for FluentLogger. Use `console` by default.

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -4,6 +4,7 @@ var msgpack = require('msgpack-lite');
 var net = require('net');
 var stream = require('stream');
 var crypto = require('crypto');
+var tls = require('tls');
 var zlib = require('zlib');
 var FluentLoggerError = require('./logger-error');
 var EventTime = require('./event-time').EventTime;
@@ -23,6 +24,8 @@ function FluentSender(tag_prefix, options) {
   this.port = options.port || 24224;
   this.path = options.path;
   this.timeout = options.timeout || 3.0;
+  this.tls = !!options.tls;
+  this.tlsOptions = options.tlsOptions || {};
   this.reconnectInterval = options.reconnectInterval || 600000; // Default is 10 minutes
   this.requireAckResponse = options.requireAckResponse;
   this.ackResponseTimeout = options.ackResponseTimeout || 190000; // Default is 190 seconds
@@ -46,7 +49,7 @@ function FluentSender(tag_prefix, options) {
     clientHostname: null,
     sharedKey: null,
     username: '',
-    passwort: ''
+    password: ''
   };
   this.sharedKeySalt = crypto.randomBytes(16).toString('hex');
   // helo, pingpong, established
@@ -223,30 +226,59 @@ FluentSender.prototype._connect = function(callback) {
 };
 
 FluentSender.prototype._doConnect = function(callback) {
-  this._socket = new net.Socket();
-  this._socket.setTimeout(this.timeout);
-  this._socket.on('error', (err) => {
-    if (this._socket) {
-      this._disconnect();
-      this._handleEvent('error', err);
-    }
-  });
-  this._socket.on('connect', () => {
-    this._handleEvent('connect');
-  });
-  if (this.path) {
-    this._socket.connect(this.path, () => {
-      callback();
+  let addHandlers = () => {
+    let errorHandler = (err) => {
+      if (this._socket) {
+        this._disconnect();
+        this._handleEvent('error', err);
+      }
+    };
+    this._socket.on('error', errorHandler);
+    this._socket.on('connect', () => {
+      this._handleEvent('connect');
     });
+    if (this.tls) {
+      this._socket.on('tlsClientError', errorHandler);
+      this._socket.on('secureConnect', () => {
+        this._handleEvent('connect');
+      });
+    }
+  };
+  if (!this.tls) {
+    this._socket = new net.Socket();
+    this._socket.setTimeout(this.timeout);
+    addHandlers();
+  }
+  if (this.path) {
+    if (this.tls) {
+      this._socket = tls.connect(Object.assign({}, this.tlsOptions, { path: this.path }), () => {
+        addHandlers();
+        callback();
+      });
+    } else {
+      this._socket.connect(this.path, () => {
+        callback();
+      });
+    }
   } else {
-    this._socket.connect(this.port, this.host, () => {
-      if (this.security.clientHostname && this.security.sharedKey) {
+    let postConnect = () => {
+      if (this.security.clientHostname && this.security.sharedKey !== null) {
         this._handshake(callback);
       } else {
         this._status = 'established';
         callback();
       }
-    });
+    };
+    if (this.tls) {
+      this._socket = tls.connect(Object.assign({}, this.tlsOptions, { host: this.host, port: this.port }), () => {
+        postConnect();
+      });
+      addHandlers();
+    } else {
+      this._socket.connect(this.port, this.host, () => {
+        postConnect();
+      });
+    }
   }
 };
 

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -252,9 +252,9 @@ FluentSender.prototype._doConnect = function(callback) {
   if (this.path) {
     if (this.tls) {
       this._socket = tls.connect(Object.assign({}, this.tlsOptions, { path: this.path }), () => {
-        addHandlers();
         callback();
       });
+      addHandlers();
     } else {
       this._socket.connect(this.path, () => {
         callback();

--- a/lib/testHelper.js
+++ b/lib/testHelper.js
@@ -1,18 +1,20 @@
 'use strict';
 var net = require('net');
+var tls = require('tls');
 var msgpack = require('msgpack-lite');
 var crypto = require('crypto');
 var zlib = require('zlib');
 
-function MockFluentdServer(options) {
+function MockFluentdServer(options, tlsOptions) {
   this._port = null;
   this._options = options;
+  this._tlsOptions = tlsOptions || {};
   this._received = [];
   this._clients  = {};
   this._state = null;
   this._nonce = null;
   this._userAuthSalt = null;
-  this._server = net.createServer((socket) => {
+  let server = (socket) => {
     var clientKey = socket.remoteAddress + ':' + socket.remotePort;
     this._clients[clientKey] = socket;
     socket.on('end', () => {
@@ -64,8 +66,15 @@ function MockFluentdServer(options) {
         }
       }
     });
-  });
-  this._server.on('connection', (socket) => {
+  };
+  var connectionEventType = 'connection';
+  if (this._tlsOptions.tls) {
+    connectionEventType = 'secureConnection';
+    this._server = tls.createServer(this._tlsOptions, server);
+  } else {
+    this._server = net.createServer(server);
+  }
+  this._server.on(connectionEventType, (socket) => {
     if (this._options.security && this._options.security.sharedKey && this._options.security.serverHostname) {
       this._state = 'helo';
       this._nonce = crypto.randomBytes(16);
@@ -179,8 +188,8 @@ MockFluentdServer.prototype.close = function(callback) {
 };
 
 module.exports = {
-  runServer: function(options, callback) {
-    var server = new MockFluentdServer(options);
+  runServer: function(options, tlsOptions, callback) {
+    var server = new MockFluentdServer(options, tlsOptions);
     server.listen(() => {
       callback(server, (_callback) => {
         // wait 100 ms to receive all messages and then close

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "mocha": "",
     "winston": "",
     "eslint": "^4.11.0",
-    "eslint-plugin-node": ""
+    "eslint-plugin-node": "",
+    "selfsigned": ""
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/test/test.sender.js
+++ b/test/test.sender.js
@@ -16,10 +16,19 @@ var codec = msgpack.createCodec();
 codec.addExtPacker(0x00, EventTime, EventTime.pack);
 codec.addExtUnpacker(0x00, EventTime.unpack);
 
-describe('FluentSender', () => {
+let doTest = (tls) => {
+  let serverOptions = {};
+  let clientOptions = {};
+  if (tls) {
+    var selfsigned = require('selfsigned');
+    var attrs = [{ name: 'commonName', value: 'foo.com' }];
+    var pems = selfsigned.generate(attrs, { days: 365 });
+    serverOptions = { tls: true, key: pems.private, cert: pems.cert, ca: pems.cert };
+    clientOptions = { tls: true, tlsOptions: { rejectUnauthorized: false } };
+  }
   it('should throw error', (done) => {
     try {
-      new sender.FluentSender('debug', { eventMode: 'Unknown' });
+      new sender.FluentSender('debug', Object.assign({}, clientOptions, { eventMode: 'Unknown' }));
     } catch (e) {
       expect(e.message).to.be.equal('Unknown event mode: Unknown');
       done();
@@ -27,8 +36,8 @@ describe('FluentSender', () => {
   });
 
   it('should send records', (done) => {
-    runServer({}, (server, finish) => {
-      var s1 = new sender.FluentSender('debug', { port: server.port });
+    runServer({}, serverOptions, (server, finish) => {
+      var s1 = new sender.FluentSender('debug', Object.assign({}, clientOptions, { port: server.port }));
       var emits = [];
       function emit(k) {
         emits.push((done) => { s1.emit('record', k, done); });
@@ -51,8 +60,8 @@ describe('FluentSender', () => {
   });
 
   it('should emit connect event', (done) => {
-    runServer({}, (server, finish) => {
-      var s = new sender.FluentSender('debug', {port: server.port});
+    runServer({}, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {port: server.port}));
       var called = false;
       s.on('connect', () => {
         called = true;
@@ -67,10 +76,10 @@ describe('FluentSender', () => {
   });
 
   it('should raise error when connection fails', (done) => {
-    var s = new sender.FluentSender('debug', {
+    var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {
       host: 'localhost',
       port: 65535
-    });
+    }));
     s.on('error', (err) => {
       expect(err.code).to.be.equal('ECONNREFUSED');
       done();
@@ -91,11 +100,11 @@ describe('FluentSender', () => {
         this.buffer.error.push(message);
       }
     };
-    var s = new sender.FluentSender('debug', {
+    var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {
       host: 'localhost',
       port: 65535,
       internalLogger: logger
-    });
+    }));
     s._setupErrorHandler((timeoutId) => {
       expect(logger.buffer.info).to.have.lengthOf(1);
       expect(logger.buffer.info[0]).to.be.equal('Fluentd will reconnect after 600 seconds');
@@ -109,8 +118,8 @@ describe('FluentSender', () => {
 
 
   it('should assure the sequence.', (done) => {
-    runServer({}, (server, finish) => {
-      var s = new sender.FluentSender('debug', {port: server.port});
+    runServer({}, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {port: server.port}));
       s.emit('1st record', { message: '1st data' });
       s.emit('2nd record', { message: '2nd data' });
       s.end('last record', { message: 'last data' }, () => {
@@ -128,8 +137,8 @@ describe('FluentSender', () => {
   });
 
   it('should allow to emit with a custom timestamp', (done) => {
-    runServer({}, (server, finish) => {
-      var s = new sender.FluentSender('debug', {port: server.port});
+    runServer({}, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {port: server.port}));
       var timestamp = new Date(2222, 12, 4);
       var timestamp_seconds_since_epoch = Math.floor(timestamp.getTime() / 1000);
 
@@ -143,8 +152,8 @@ describe('FluentSender', () => {
   });
 
   it('should allow to emit with a custom numeric timestamp', (done) => {
-    runServer({}, (server, finish) => {
-      var s = new sender.FluentSender('debug', {port: server.port});
+    runServer({}, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {port: server.port}));
       var timestamp = Math.floor(new Date().getTime() / 1000);
 
       s.emit('1st record', { message: '1st data' }, timestamp, () => {
@@ -157,8 +166,8 @@ describe('FluentSender', () => {
   });
 
   it('should allow to emit with a EventTime', (done) => {
-    runServer({}, (server, finish) => {
-      var s = new sender.FluentSender('debug', {port: server.port});
+    runServer({}, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {port: server.port}));
       var eventTime = EventTime.now();
 
       s.emit('1st record', { message: '1st data' }, eventTime, () => {
@@ -172,11 +181,11 @@ describe('FluentSender', () => {
   });
 
   it('should resume the connection automatically and flush the queue', (done) => {
-    var s = new sender.FluentSender('debug');
+    var s = new sender.FluentSender('debug', clientOptions);
     s.emit('1st record', { message: '1st data' });
     s.on('error', (err) => {
       expect(err.code).to.be.equal('ECONNREFUSED');
-      runServer({}, (server, finish) => {
+      runServer({}, serverOptions, (server, finish) => {
         s.port = server.port;
         s.emit('2nd record', { message: '2nd data' });
         s.end('last record', { message: 'last data' }, () => {
@@ -195,15 +204,15 @@ describe('FluentSender', () => {
   });
 
   it('should reconnect when fluentd close the client socket suddenly', (done) => {
-    runServer({}, (server, finish) => {
-      var s = new sender.FluentSender('debug', {port: server.port});
+    runServer({}, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {port: server.port}));
       s.emit('foo', 'bar', () => {
         // connected
         server.close(() => {
           // waiting for the server closing all client socket.
           (function waitForUnwritable() {
             if (!(s._socket && s._socket.writable)) {
-              runServer({}, (_server2, finish) => {
+              runServer({}, serverOptions, (_server2, finish) => {
                 s.port = _server2.port;   // in actuall case, s.port does not need to be updated.
                 s.emit('bar', { message: 'hoge' }, () => {
                   finish((data) => {
@@ -225,11 +234,11 @@ describe('FluentSender', () => {
   });
 
   it('should send records with requireAckResponse', (done) => {
-    runServer({requireAckResponse: true}, (server, finish) => {
-      var s1 = new sender.FluentSender('debug', {
+    runServer({requireAckResponse: true}, serverOptions, (server, finish) => {
+      var s1 = new sender.FluentSender('debug', Object.assign({}, clientOptions, {
         port: server.port,
         requireAckResponse: true
-      });
+      }));
       var emits = [];
       function emit(k) {
         emits.push((done) => { s1.emit('record', k, done); });
@@ -253,12 +262,12 @@ describe('FluentSender', () => {
   });
 
   it('should send records ackResponseTimeout', (done) => {
-    runServer({requireAckResponse: false }, (server, finish) => {
-      var s1 = new sender.FluentSender('debug', {
+    runServer({requireAckResponse: false }, serverOptions, (server, finish) => {
+      var s1 = new sender.FluentSender('debug', Object.assign({}, clientOptions, {
         port: server.port,
         requireAckResponse: false,
         ackResponseTimeout: 1000
-      });
+      }));
       s1.on('response-timeout', (error) => {
         expect(error).to.be.equal('ack response timeout');
       });
@@ -271,9 +280,9 @@ describe('FluentSender', () => {
   });
 
   it('should set error handler', (done) => {
-    var s = new sender.FluentSender('debug', {
+    var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {
       reconnectInterval: 100
-    });
+    }));
     expect(s._eventEmitter.listeners('error').length).to.be.equal(0);
     s._setupErrorHandler();
     expect(s._eventEmitter.listeners('error').length).to.be.equal(1);
@@ -368,8 +377,8 @@ describe('FluentSender', () => {
     }
   ].forEach((testCase) => {
     it('should send records with ' + testCase.name + ' arguments', (done) => {
-      runServer({}, (server, finish) => {
-        var s1 = new sender.FluentSender('debug', { port: server.port });
+      runServer({}, serverOptions, (server, finish) => {
+        var s1 = new sender.FluentSender('debug', Object.assign({}, clientOptions, { port: server.port }));
         s1.emit.apply(s1, testCase.args);
 
         finish((data) => {
@@ -432,8 +441,8 @@ describe('FluentSender', () => {
     }
   ].forEach((testCase) => {
     it('should send records with ' + testCase.name + ' arguments without a default tag', (done) => {
-      runServer({}, (server, finish) => {
-        var s1 = new sender.FluentSender(null, { port: server.port });
+      runServer({}, serverOptions, (server, finish) => {
+        var s1 = new sender.FluentSender(null, Object.assign({}, clientOptions, { port: server.port }));
         s1.emit.apply(s1, testCase.args);
 
         finish((data) => {
@@ -483,8 +492,8 @@ describe('FluentSender', () => {
     }
   ].forEach((testCase) => {
     it('should not send records with ' + testCase.name + ' arguments without a default tag', (done) => {
-      runServer({}, (server, finish) => {
-        var s1 = new sender.FluentSender(null, { port: server.port });
+      runServer({}, serverOptions, (server, finish) => {
+        var s1 = new sender.FluentSender(null, Object.assign({}, clientOptions, { port: server.port }));
         s1.on('error', (error) => {
           expect(error.name).to.be.equal('MissingTagError');
         });
@@ -506,8 +515,8 @@ describe('FluentSender', () => {
   });
 
   it('should not send records is not object', (done) => {
-    runServer({}, (server, finish) => {
-      var s1 = new sender.FluentSender(null, { port: server.port });
+    runServer({}, serverOptions, (server, finish) => {
+      var s1 = new sender.FluentSender(null, Object.assign({}, clientOptions, { port: server.port }));
       s1.on('error', (error) => {
         expect(error.name).to.be.equal('DataTypeError');
       });
@@ -520,7 +529,7 @@ describe('FluentSender', () => {
   });
 
   it('should set max listeners', (done) => {
-    var s = new sender.FluentSender('debug');
+    var s = new sender.FluentSender('debug', clientOptions);
     if (EventEmitter.prototype.getMaxListeners) {
       expect(s.getMaxListeners()).to.be.equal(10);
     }
@@ -535,8 +544,8 @@ describe('FluentSender', () => {
 
   // Internal behavior test.
   it('should not flush queue if existing connection is unavailable.', (done) => {
-    runServer({}, (server, finish) => {
-      var s = new sender.FluentSender('debug', {port: server.port});
+    runServer({}, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {port: server.port}));
       s.emit('1st record', { message: '1st data' }, () => {
         s._disconnect();
         s.emit('2nd record', { message: '2nd data' }, () => {
@@ -553,8 +562,8 @@ describe('FluentSender', () => {
   });
 
   it('should write stream.', (done) => {
-    runServer({}, (server, finish) => {
-      var s = new sender.FluentSender('debug', { port: server.port });
+    runServer({}, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, { port: server.port }));
       var ss = s.toStream('record');
       var pt = new stream.PassThrough();
       pt.pipe(ss);
@@ -577,13 +586,13 @@ describe('FluentSender', () => {
   });
 
   it('should process messages step by step on requireAckResponse=true', (done) => {
-    runServer({ requireAckResponse: true }, (server, finish) => {
-      var s = new sender.FluentSender('debug', {
+    runServer({ requireAckResponse: true }, serverOptions, (server, finish) => {
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, {
         port: server.port,
         timeout: 3.0,
         reconnectInterval: 600000,
         requireAckResponse: true
-      });
+      }));
       var errors = [];
       s.on('error', (err) => {
         errors.push(count + ': ' + err);
@@ -609,7 +618,7 @@ describe('FluentSender', () => {
   });
 
   it('should process entries when using PackedForward Mode', (done) => {
-    runServer({}, (server, finish) => {
+    runServer({}, serverOptions, (server, finish) => {
       let loggerOptions = {
         port: server.port,
         eventMode: 'PackedForward',
@@ -618,7 +627,7 @@ describe('FluentSender', () => {
           error: () => {}
         }
       };
-      var s = new sender.FluentSender('debug', loggerOptions);
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, loggerOptions));
       s.emit('test', { message: 'This is test 0' });
       s.end('test', { message: 'This is test 1' });
       setTimeout(() => {
@@ -635,7 +644,7 @@ describe('FluentSender', () => {
   });
 
   it('should compress entries when using CompressedPackedForward Mode', (done) => {
-    runServer({}, (server, finish) => {
+    runServer({}, serverOptions, (server, finish) => {
       let loggerOptions = {
         port: server.port,
         eventMode: 'CompressedPackedForward',
@@ -644,7 +653,7 @@ describe('FluentSender', () => {
           error: () => {}
         }
       };
-      var s = new sender.FluentSender('debug', loggerOptions);
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, loggerOptions));
       s.emit('test', { message: 'This is test 0' });
       s.emit('test', { message: 'This is test 1' });
       setTimeout(() => {
@@ -668,7 +677,7 @@ describe('FluentSender', () => {
         sharedKey: sharedKey
       }
     };
-    runServer(options, (server, finish) => {
+    runServer(options, serverOptions, (server, finish) => {
       let loggerOptions = {
         port: server.port,
         security: {
@@ -680,7 +689,7 @@ describe('FluentSender', () => {
           error: () => {}
         }
       };
-      var s = new sender.FluentSender('debug', loggerOptions);
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, loggerOptions));
       s.emit('test', { message: 'This is test 0' });
       s.emit('test', { message: 'This is test 1' });
       finish((data) => {
@@ -702,7 +711,7 @@ describe('FluentSender', () => {
         sharedKey: sharedKey
       }
     };
-    runServer(options, (server, finish) => {
+    runServer(options, serverOptions, (server, finish) => {
       let loggerOptions = {
         port: server.port,
         security: {
@@ -714,7 +723,7 @@ describe('FluentSender', () => {
           error: () => {}
         }
       };
-      var s = new sender.FluentSender('debug', loggerOptions);
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, loggerOptions));
       s.on('error', (error) => {
         expect(error.message).to.be.equal('Authentication failed: shared key mismatch');
       });
@@ -736,7 +745,7 @@ describe('FluentSender', () => {
         password: 'password'
       }
     };
-    runServer(options, (server, finish) => {
+    runServer(options, serverOptions, (server, finish) => {
       let loggerOptions = {
         port: server.port,
         security: {
@@ -750,7 +759,7 @@ describe('FluentSender', () => {
           error: () => {}
         }
       };
-      var s = new sender.FluentSender('debug', loggerOptions);
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, loggerOptions));
       s.emit('test', { message: 'This is test 0' });
       s.emit('test', { message: 'This is test 1' });
       finish((data) => {
@@ -774,7 +783,7 @@ describe('FluentSender', () => {
         password: 'password'
       }
     };
-    runServer(options, (server, finish) => {
+    runServer(options, serverOptions, (server, finish) => {
       let loggerOptions = {
         port: server.port,
         security: {
@@ -788,7 +797,7 @@ describe('FluentSender', () => {
           error: () => {}
         }
       };
-      var s = new sender.FluentSender('debug', loggerOptions);
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, loggerOptions));
       s.on('error', (error) => {
         expect(error.message).to.be.equal('Authentication failed: username/password mismatch');
       });
@@ -809,7 +818,7 @@ describe('FluentSender', () => {
       },
       checkPing: (data) => { return { succeeded: false, reason: 'reason', sharedKeySalt: null }; }
     };
-    runServer(options, (server, finish) => {
+    runServer(options, serverOptions, (server, finish) => {
       let loggerOptions = {
         port: server.port,
         security: {
@@ -821,7 +830,7 @@ describe('FluentSender', () => {
           error: () => {}
         }
       };
-      var s = new sender.FluentSender('debug', loggerOptions);
+      var s = new sender.FluentSender('debug', Object.assign({}, clientOptions, loggerOptions));
       s.on('error', (err) => {
         expect(err.message).to.be.equal('Authentication failed: reason');
       });
@@ -832,4 +841,12 @@ describe('FluentSender', () => {
       });
     });
   });
+};
+
+describe('FluentSender', () => {
+  doTest();
+});
+
+describe('FluentSenderWithTLS', () => {
+  doTest(true);
 });

--- a/test/test.winston.js
+++ b/test/test.winston.js
@@ -17,7 +17,7 @@ describe('winston', () => {
   describe('transport', () => {
 
     it('should send log records', (done) => {
-      runServer({}, (server, finish) => {
+      runServer({}, {}, (server, finish) => {
         var logger = new (winston.Logger)({
           transports: [
             new (winstonSupport.Transport)('debug', {port: server.port})


### PR DESCRIPTION
This PR adds support for TLS to allow securely connecting to a Fluent server in secure_forward mode.

Add tls option to enable tls over fluent socket
  Add tlsOptions option to pass additional tls related options to tls.connect
  Duplicate FluentSender tests for tls case