### PR TITLE
fix: add generic param to createFluentSender

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -76,6 +76,19 @@ declare namespace fluentLogger {
   
   function configure(tag: string, options: Options): void;
   function createFluentSender<T>(tag: string, options: Options): FluentSender<T>;
+
+  function emit<T>(data: T, callback?: Callback): void;
+  function emit<T>(data: T, timestamp: Timestamp, callback?: Callback): void;
+  function emit<T>(label: string, data: T, callback?: Callback): void;
+  function emit<T>(label: string, data: T, timestamp: Timestamp, callback?: Callback): void;
+  function end<T>(label: string, data: T, callback: Callback): void;
+
+  function on(event: string | symbol, listener: (...args: any[]) => void): void;
+  function once(event: string | symbol, listener: (...args: any[]) => void): void;
+  function removeListener(event: string | symbol, listener: (...args: any[]) => void): void;
+  function removeAllListeners(event?: string | symbol): void;
+  function setMaxListeners(n: number): void;
+  function getMaxListeners(): number;
 }
 
 export = fluentLogger;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -75,7 +75,7 @@ declare namespace fluentLogger {
   let EventTime: InnerEventTime;
   
   function configure(tag: string, options: Options): void;
-  function createFluentSender(tag: string, options: Options): FluentSender;
+  function createFluentSender<T>(tag: string, options: Options): FluentSender<T>;
 }
 
 export = fluentLogger;


### PR DESCRIPTION
With typescript, if there no generic param with `FluentSender` will case compile error.