### PR TITLE
update type definition according to documentation for security

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -29,8 +29,8 @@ declare namespace fluentLogger {
   interface Security {
     clientHostname: string;
     sharedKey: string;
-    username: string;
-    password: string;
+    username?: string;
+    password?: string;
   }
 
   interface StreamOptions {


### PR DESCRIPTION
Hi,

There is a difference between the documentation and the type definition. Documentations states that

```
security.username
Set username for user based authentication. Default values is empty string.

security.password
Set password for user based authentication. Default values is empty string.
```

However in type definition they are both required