### PR TITLE
Gracefully free resources on `.end()`

### DIFF
--- a/lib/winston.js
+++ b/lib/winston.js
@@ -48,4 +48,13 @@ module.exports = class FluentTransport extends Transport {
       });
     });
   }
+
+  _final(callback) {
+    if (!this.sender) return process.nextTick(callback);
+
+    this.sender.end(null, null, () => {
+      this.sender = null;
+      callback();
+    });
+  }
 };


### PR DESCRIPTION
The `winston` Logger attempts to call `.end()` on every transport it is currently piped to before emitting the `finish` event (see: [logger.js](https://github.com/winstonjs/winston/blob/master/lib/winston/logger.js#L314-L330))

By implementing `_final(callback)` from the `WritableStream` API we ensure that any resources from the `FluentSender` are cleaned up (e.g. sockets that need to be destroyed).

> p.s. thanks for helping grow & support the `winston` ecosystem 👍🥇💯 