### PR TITLE
Revert remove type definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -75,6 +75,10 @@ declare namespace fluentLogger {
     static fromDate(date: Date): InnerEventTime;
     static fromTimestamp(t: number): InnerEventTime;
   }
+  
+  let support: {	
+    winstonTransport: () => Constructable<FluentTransport, Options>	
+  };
 
   interface Constructable<T, U> {
     new(tag: string, options: U) : T;


### PR DESCRIPTION
Relate to #161 

This revert deleted lines of type definition related to Winston logger