### PR TITLE
Proposing the use of custom Queue implementation for message event mode

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -8,6 +8,7 @@ const tls = require('tls');
 const zlib = require('zlib');
 const FluentLoggerError = require('./logger-error');
 const EventTime = require('./event-time');
+const Queue = require('tiny-queue');
 
 const codec = msgpack.createCodec();
 codec.addExtPacker(0x00, EventTime, EventTime.pack);
@@ -35,7 +36,7 @@ class FluentSender {
     this._timeResolution = options.milliseconds ? 1 : 1000;
     this._socket = null;
     if (this._eventMode === 'Message') {
-      this._sendQueue = []; // queue for items waiting for being sent.
+      this._sendQueue = new Queue(); // queue for items waiting for being sent.
       this._flushInterval = 0;
       this._messageQueueSizeLimit = options.messageQueueSizeLimit || 0;
     } else {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "node": ">=6"
   },
   "dependencies": {
-    "msgpack-lite": "*"
+    "msgpack-lite": "*",
+    "tiny-queue": "^0.2.1"
   },
   "devDependencies": {
     "async": "*",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chai": "*",
     "eslint": "^5.1.0",
     "eslint-plugin-node": "*",
-    "mocha": "*",
+    "mocha": "^6.0.0",
     "selfsigned": "*",
     "winston": "*"
   },

--- a/test/test.queue-performance.js
+++ b/test/test.queue-performance.js
@@ -55,4 +55,4 @@ describe('queue performance', () => {
     console.log(`Queue time: ${totalQueue[0] + totalQueue[1] / 1e9}`);
     expect(totalArray[0] + totalArray[1] / 1e9 - (totalQueue[0] + totalQueue[1] / 1e9) < 0.001).to.be.true;
   });
-})
+});

--- a/test/test.queue-performance.js
+++ b/test/test.queue-performance.js
@@ -30,4 +30,29 @@ describe('queue performance', () => {
     console.log(`Queue time: ${totalQueue[0] + totalQueue[1] / 1e9}`);
     expect(totalArray[0] + totalArray[1] / 1e9 > (totalQueue[0] + totalQueue[1] / 1e9) * 100).to.be.true;
   });
+
+  it('the time difference between array.shift and queue.shift should be irrelevant for small lengths', () => {
+    const array = [];
+    const queue = new Queue();
+    for (let i = 1; i < 10000; i++) {
+      array.push(i);
+      queue.push(i);
+    }
+
+
+    const startQueue = process.hrtime();
+    while (queue.length > 0) {
+      queue.shift();
+    }
+    const totalQueue = process.hrtime(startQueue);
+    const startArray = process.hrtime();
+    while (array.length > 0) {
+      array.shift();
+    }
+    const totalArray = process.hrtime(startArray);
+
+    console.log(`Array time: ${totalArray[0] + totalArray[1] / 1e9}`);
+    console.log(`Queue time: ${totalQueue[0] + totalQueue[1] / 1e9}`);
+    expect(totalArray[0] + totalArray[1] / 1e9 - (totalQueue[0] + totalQueue[1] / 1e9) < 0.001).to.be.true;
+  });
 })

--- a/test/test.queue-performance.js
+++ b/test/test.queue-performance.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-console */
+'use strict';
+/* globals describe, it */
+/* eslint node/no-unpublished-require: ["error", {"allowModules": ["chai"]}] */
+const expect = require('chai').expect;
+const Queue = require('tiny-queue');
+
+describe('queue performance', () => {
+  it('should be more than 100 times faster than array for large lengths', () => {
+    const array = [];
+    const queue = new Queue();
+    for (let i = 1; i < 100000; i++) {
+      array.push(i);
+      queue.push(i);
+    }
+
+
+    const startQueue = process.hrtime();
+    while (queue.length > 0) {
+      queue.shift();
+    }
+    const totalQueue = process.hrtime(startQueue);
+    const startArray = process.hrtime();
+    while (array.length > 0) {
+      array.shift();
+    }
+    const totalArray = process.hrtime(startArray);
+
+    console.log(`Array time: ${totalArray[0] + totalArray[1] / 1e9}`);
+    console.log(`Queue time: ${totalQueue[0] + totalQueue[1] / 1e9}`);
+    expect(totalArray[0] + totalArray[1] / 1e9 > (totalQueue[0] + totalQueue[1] / 1e9) * 100).to.be.true;
+  });
+})

--- a/test/test.sender.js
+++ b/test/test.sender.js
@@ -960,9 +960,9 @@ let doTest = (tls) => {
         s.emit('message3', {});
         s.emit('message4', {});
         expect(s._sendQueue.length).to.be.equal(3);
-        expect(s._sendQueue[0].tag).to.be.equal('debug.message2');
-        expect(s._sendQueue[1].tag).to.be.equal('debug.message3');
-        expect(s._sendQueue[2].tag).to.be.equal('debug.message4');
+        expect(s._sendQueue.shift().tag).to.be.equal('debug.message2');
+        expect(s._sendQueue.shift().tag).to.be.equal('debug.message3');
+        expect(s._sendQueue.shift().tag).to.be.equal('debug.message4');
         done();
       });
     });


### PR DESCRIPTION
### Motivation

As array.shift needs to reindex the whole array for each execution, this can be pretty processing expensive if you need to do it in a high frequency.
Though a custom Queue implementation will loose to native array shift in cases where there is not much items to deal with, the difference of time in this cases seems to be irrelevant.
So, it is worth it to use a custom Queue implementation to have a faster and less cpu demanding shift processing.

There is a lot of Queue implementations out there, I just choose one of them with a simple implementation and more array like for this PR.