### PR TITLE
Align comment with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ logger.configure('tag_prefix', {
    reconnectInterval: 600000 // 10 minutes
 });
 
-// send an event record with 'tag.label'
+// send an event record with 'tag_prefix.label'
 logger.emit('label', {record: 'this is a log'});
 ```
 


### PR DESCRIPTION
The label passed in the configuration is `tag_prefix` and not `tag`. 

```
logger.configure('tag_prefix', {
   host: 'localhost',
   port: 24224,
   timeout: 3.0,
   reconnectInterval: 600000 // 10 minutes
});
```